### PR TITLE
Remove warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,7 +223,7 @@ pub mod pdu {
         fn default() -> Buf {
             Buf {
                 len: 0,
-                buf: unsafe { mem::uninitialized() },
+                buf: unsafe { mem::MaybeUninit::uninit().assume_init() },
             }
         }
     }
@@ -267,6 +267,7 @@ pub mod pdu {
             where F: FnMut(&mut Self)
         {
             let before_len = self.len;
+
             f(self);
             let written = self.len - before_len;
             self.push_length(written);
@@ -624,7 +625,7 @@ pub type ObjIdBuf = [u32; 128];
 
 impl<'a> fmt::Display for ObjectIdentifier<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let mut buf: ObjIdBuf = unsafe { mem::uninitialized() };
+        let mut buf: ObjIdBuf = unsafe { mem::MaybeUninit::uninit().assume_init() };
         let mut first = true;
         match self.read_name(&mut buf) {
             Ok(name) => {
@@ -645,7 +646,7 @@ impl<'a> fmt::Display for ObjectIdentifier<'a> {
 
 impl<'a> PartialEq<[u32]> for ObjectIdentifier<'a> {
     fn eq(&self, other: &[u32]) -> bool {
-        let mut buf: ObjIdBuf = unsafe { mem::uninitialized() };
+        let mut buf: ObjIdBuf = unsafe { mem::MaybeUninit::uninit().assume_init() };
         if let Ok(name) = self.read_name(&mut buf) {
             name == other
         } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,9 +177,9 @@ pub mod snmp {
     pub const TYPE_OPAQUE:     u8 = asn1::CLASS_APPLICATION | 4;
     pub const TYPE_COUNTER64:  u8 = asn1::CLASS_APPLICATION | 6;
 
-    pub const SNMP_NOSUCHOBJECT:   u8 = (asn1::CLASS_CONTEXTSPECIFIC | asn1::PRIMITIVE | 0x0); /* 80=128 */
-    pub const SNMP_NOSUCHINSTANCE: u8 = (asn1::CLASS_CONTEXTSPECIFIC | asn1::PRIMITIVE | 0x1); /* 81=129 */
-    pub const SNMP_ENDOFMIBVIEW:   u8 = (asn1::CLASS_CONTEXTSPECIFIC | asn1::PRIMITIVE | 0x2); /* 82=130 */
+    pub const SNMP_NOSUCHOBJECT:   u8 = asn1::CLASS_CONTEXTSPECIFIC | asn1::PRIMITIVE | 0x0; /* 80=128 */
+    pub const SNMP_NOSUCHINSTANCE: u8 = asn1::CLASS_CONTEXTSPECIFIC | asn1::PRIMITIVE | 0x1; /* 81=129 */
+    pub const SNMP_ENDOFMIBVIEW:   u8 = asn1::CLASS_CONTEXTSPECIFIC | asn1::PRIMITIVE | 0x2; /* 82=130 */
 
     pub const ERRSTATUS_NOERROR:             u32 =  0;
     pub const ERRSTATUS_TOOBIG:              u32 =  1;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,7 @@
 use super::{AsnReader, SnmpError};
 use super::{pdu, snmp};
 
+
 #[test]
 fn build_getnext_pdu() {
     let mut pdu = pdu::Buf::default();
@@ -69,4 +70,13 @@ fn asn_parse_getnext_pdu() {
             })
         })
     }).unwrap();
+    /*
+    let mut sess = SyncSession::new("10.0.251.15:161", b"sTrnG4u2w2SW",
+        Some(Duration::from_secs(20)), 0).unwrap();
+    let mut response = sess.getnext(&[1,3,6,1,2,1,1,1,]).unwrap();
+    if let Some((_oid, Value::OctetString(sys_descr))) = response.varbinds.next() {
+        println!("{}", String::from_utf8_lossy(sys_descr));
+    }
+
+     */
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,7 +1,6 @@
 use super::{AsnReader, SnmpError};
 use super::{pdu, snmp};
 
-
 #[test]
 fn build_getnext_pdu() {
     let mut pdu = pdu::Buf::default();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -70,13 +70,4 @@ fn asn_parse_getnext_pdu() {
             })
         })
     }).unwrap();
-    /*
-    let mut sess = SyncSession::new("10.0.251.15:161", b"sTrnG4u2w2SW",
-        Some(Duration::from_secs(20)), 0).unwrap();
-    let mut response = sess.getnext(&[1,3,6,1,2,1,1,1,]).unwrap();
-    if let Some((_oid, Value::OctetString(sys_descr))) = response.varbinds.next() {
-        println!("{}", String::from_utf8_lossy(sys_descr));
-    }
-
-     */
 }


### PR DESCRIPTION
Removed warnings regarding deprecation for mem::uninitialized and changed to mem::MaybeUninit::uninit().assume_init()